### PR TITLE
兼容http和https混合 index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -12,6 +12,7 @@
 <html lang="zh-CN">
 
 <head>
+        <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">	
 	<?php $this->need('public/include.php'); ?>
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@5.4.5/css/swiper.min.css" />
 	<script src="https://cdn.jsdelivr.net/npm/swiper@5.4.5/js/swiper.min.js"></script>


### PR DESCRIPTION
如果同时出现http和https的使用者，将无法正常返回
```
jquery.min.js:2 Mixed Content: 
The page at 
'https://www.domain.com/' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://www.domain.com/joe/api'. This request has been blocked; the content must be served over HTTPS.
```
兼容http和https混合