### PR TITLE
fix: 修复BUG

### DIFF
--- a/public/config.php
+++ b/public/config.php
@@ -15,7 +15,7 @@
   }
 </script>
 <?php
-$fontUrl = $this->options->JCustomFont;
+$fontUrl = $this->options->JCustomFont ?? '';
 if (strpos($fontUrl, 'woff2') !== false) $fontFormat = 'woff2';
 elseif (strpos($fontUrl, 'woff') !== false) $fontFormat = 'woff';
 elseif (strpos($fontUrl, 'ttf') !== false) $fontFormat = 'truetype';


### PR DESCRIPTION
[问题] strpos() 报警告提示
[原因] PHP8.0环境下 strpos()第一个参数不允许传递 null
[处理] 使用空合并运算符，赋予默认值空字符串
[结果] 警告消失